### PR TITLE
Update dependencies: PHP 8.4+, PHPUnit 13, PHPCS 4.x

### DIFF
--- a/.github/workflows/phpci.yaml
+++ b/.github/workflows/phpci.yaml
@@ -11,15 +11,13 @@ jobs:
     strategy:
       matrix:
         php-versions:
-          - '8.3'
           - '8.4'
-          - '8.5'
 
     steps:
     - uses: actions/checkout@v6
 
     - name: Set up PHP ${{ matrix.php-versions }}
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@v2.37.0
       with:
         php-version: ${{ matrix.php-versions }}
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=8.3"
+        "php": ">=8.4"
     },
     "autoload": {
         "files": [
@@ -18,7 +18,7 @@
         ]
     },
     "require-dev": {
-        "phpunit/phpunit": "^12",
-        "squizlabs/php_codesniffer": "*"
+        "phpunit/phpunit": "^13",
+        "phpcsstandards/php_codesniffer": "^4.0"
     }
 }


### PR DESCRIPTION
## Summary

Update project dependencies to latest stable versions:

### Changes
- **PHP**:  → 
- **phpunit/phpunit**:  → 
- **php_codesniffer**:  (abandoned) →  
- **CI**: PHP 8.4 only, setup-php@v2.37.0

### Breaking Changes
- PHPUnit 13 requires PHP 8.4+ (CI updated accordingly)
- PHPCS 4.x is a significant update with breaking changes for custom sniffs (not applicable here)

### Verification
- composer exec phpunit -- tests
PHPUnit 13.1.12 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.5.5
Configuration: /Users/asakasinsky/Workspace/hexlet/ai-assisted-development-fundamentals/php-pairs/phpunit.xml

...                                                                 3 / 3 (100%)

Time: 00:00, Memory: 16.00 MB

[4mPairs (Php\Pairs\Tests\Pairs)[0m
[32m ✔ [0mPairs
[32m ✔ [0mTo string
[32m ✔ [0mCheck pair

[30;42mOK (3 tests, 7 assertions)[0m ✅ (3 tests, 7 assertions)
- composer exec phpcs ✅ (no errors)